### PR TITLE
feat: #266 - shift+click to select range in transactions table

### DIFF
--- a/components/TransactionTable/DescriptionCell.tsx
+++ b/components/TransactionTable/DescriptionCell.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+type Props = {
+  value: string;
+  onCopy: (text: string) => void;
+};
+
+export default function DescriptionCell({ value, onCopy }: Props) {
+  const ref = useRef<HTMLButtonElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  const handleMouseEnter = useCallback(() => {
+    const el = ref.current;
+    if (el) {
+      setIsTruncated(el.scrollWidth > el.clientWidth);
+    }
+  }, []);
+
+  const trigger = (
+    <button
+      ref={ref}
+      type="button"
+      className="block max-w-[200px] cursor-pointer truncate"
+      onMouseEnter={handleMouseEnter}
+      onClick={() => onCopy(value)}
+    >
+      {value}
+    </button>
+  );
+
+  if (!isTruncated) return trigger;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+      <TooltipContent>{value}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/components/TransactionTable/TransactionTable.tsx
+++ b/components/TransactionTable/TransactionTable.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import {
+  type RowSelectionState,
+  flexRender,
+} from '@tanstack/react-table';
+import { ArrowDown, ArrowUp } from 'lucide-react';
+import ConfirmationDialog from '@/components/ConfirmationDialog';
+import CreateUpdateTransactionDialog from '@/components/CreateUpdateTransactionDialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import useTransactionTable from '@/components/TransactionTable/useTransactionTable';
+import type { UseTransactionTableArgs } from '@/components/TransactionTable/useTransactionTable';
+
+export default function TransactionTable(props: UseTransactionTableArgs) {
+  const {
+    scrollRef,
+    table,
+    columns,
+    rows,
+    virtualizer,
+    isDeleteDialogOpen,
+    isDeleting,
+    onDeleteDialogClose,
+    handleDelete,
+    transactionToUpdate,
+    isUpdateDialogOpen,
+    isUpdating,
+    accounts,
+    onUpdateDialogClose,
+    updateTransaction,
+  } = useTransactionTable(props);
+
+  return (
+    <>
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
+        <Table>
+          <TableHeader className="sticky top-0 z-10 bg-background">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    style={{ width: header.getSize() }}
+                    className={
+                      header.column.getCanSort()
+                        ? 'cursor-pointer select-none'
+                        : ''
+                    }
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    <span className="flex items-center gap-1">
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext(),
+                      )}
+                      {header.column.getIsSorted() === 'asc' ? (
+                        <ArrowUp className="size-3" />
+                      ) : header.column.getIsSorted() === 'desc' ? (
+                        <ArrowDown className="size-3" />
+                      ) : null}
+                    </span>
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {virtualizer.getVirtualItems().length > 0 ? (
+              <>
+                {virtualizer.getVirtualItems()[0]?.start > 0 && (
+                  <tr key="spacer-top">
+                    <td
+                      colSpan={columns.length}
+                      style={{
+                        height: virtualizer.getVirtualItems()[0]?.start ?? 0,
+                        padding: 0,
+                      }}
+                    />
+                  </tr>
+                )}
+                {virtualizer.getVirtualItems().map((virtualRow) => {
+                  const row = rows[virtualRow.index];
+                  return (
+                    <TableRow
+                      key={virtualRow.index}
+                      data-index={virtualRow.index}
+                      data-state={row.getIsSelected() ? 'selected' : undefined}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  );
+                })}
+                {virtualizer.getTotalSize() -
+                  (virtualizer.getVirtualItems().at(-1)?.end ?? 0) >
+                  0 && (
+                  <tr key="spacer-bottom">
+                    <td
+                      colSpan={columns.length}
+                      style={{
+                        height:
+                          virtualizer.getTotalSize() -
+                          (virtualizer.getVirtualItems().at(-1)?.end ?? 0),
+                        padding: 0,
+                      }}
+                    />
+                  </tr>
+                )}
+              </>
+            ) : null}
+          </TableBody>
+        </Table>
+      </div>
+
+      <ConfirmationDialog
+        id="delete-transaction"
+        title="Delete transaction"
+        open={isDeleteDialogOpen}
+        loading={isDeleting}
+        onClose={onDeleteDialogClose}
+        onConfirm={handleDelete}
+      >
+        <p>
+          Are you sure you want to delete this transaction? This action cannot
+          be undone.
+        </p>
+      </ConfirmationDialog>
+
+      {transactionToUpdate ? (
+        <CreateUpdateTransactionDialog
+          transaction={transactionToUpdate}
+          open={isUpdateDialogOpen}
+          loading={isUpdating}
+          accounts={accounts}
+          onClose={onUpdateDialogClose}
+          onUpdate={updateTransaction}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/components/TransactionTable/index.ts
+++ b/components/TransactionTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from '@/components/TransactionTable/TransactionTable';


### PR DESCRIPTION
## Summary
- Adds shift+click support to the transaction table checkboxes to select a contiguous range of rows
- Tracks the last selected row by ID (stable across re-renders and re-sorts)
- Looks up row positions in the sorted row model at click time, so range selection respects the current table sort order

Closes #266

## Test plan
- [ ] Click a checkbox to select a row, then shift+click another checkbox further down — all rows in between should be selected
- [ ] Change the table sort order (e.g., sort by amount), repeat — range selection should follow visual order
- [ ] Shift+click without a prior selection anchor — should behave as a normal click
- [ ] Verify existing single-click and select-all checkbox behavior still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)