### PR TITLE
feat: #272 - improve bulk edit transactions UX

### DIFF
--- a/components/BulkEditTransactionsDialog.tsx
+++ b/components/BulkEditTransactionsDialog.tsx
@@ -58,20 +58,21 @@ export default function BulkEditTransactionsDialog({
   onClose,
   onUpdate,
 }: Props) {
-  const { control, register, handleSubmit, watch } = useForm<FormValues>({
-    defaultValues: {
-      amountEnabled: false,
-      amount: '',
-      dateEnabled: false,
-      date: format(new Date(), 'yyyy-MM-dd'),
-      descriptionEnabled: false,
-      description: '',
-      typeEnabled: false,
-      type: 'Expense',
-      categoryEnabled: false,
-      categoryId: '',
-    },
-  });
+  const { control, register, handleSubmit, watch, setValue } =
+    useForm<FormValues>({
+      defaultValues: {
+        amountEnabled: false,
+        amount: '',
+        dateEnabled: false,
+        date: format(new Date(), 'yyyy-MM-dd'),
+        descriptionEnabled: false,
+        description: '',
+        typeEnabled: false,
+        type: 'Expense',
+        categoryEnabled: false,
+        categoryId: '',
+      },
+    });
 
   const amountEnabled = watch('amountEnabled');
   const dateEnabled = watch('dateEnabled');
@@ -136,7 +137,13 @@ export default function BulkEditTransactionsDialog({
               control={control}
               name="amountEnabled"
               render={({ field: { value, onChange } }) => (
-                <Checkbox checked={value} onCheckedChange={onChange} />
+                <Checkbox
+                  checked={value}
+                  onCheckedChange={(checked) => {
+                    onChange(checked);
+                    if (!checked) setValue('amount', '');
+                  }}
+                />
               )}
             />
             <Label htmlFor="bulk-amount" className="w-24 shrink-0">
@@ -156,7 +163,13 @@ export default function BulkEditTransactionsDialog({
               control={control}
               name="dateEnabled"
               render={({ field: { value, onChange } }) => (
-                <Checkbox checked={value} onCheckedChange={onChange} />
+                <Checkbox
+                  checked={value}
+                  onCheckedChange={(checked) => {
+                    onChange(checked);
+                    if (!checked) setValue('date', '');
+                  }}
+                />
               )}
             />
             <Label htmlFor="bulk-date" className="w-24 shrink-0">
@@ -175,7 +188,13 @@ export default function BulkEditTransactionsDialog({
               control={control}
               name="descriptionEnabled"
               render={({ field: { value, onChange } }) => (
-                <Checkbox checked={value} onCheckedChange={onChange} />
+                <Checkbox
+                  checked={value}
+                  onCheckedChange={(checked) => {
+                    onChange(checked);
+                    if (!checked) setValue('description', '');
+                  }}
+                />
               )}
             />
             <Label htmlFor="bulk-description" className="w-24 shrink-0">
@@ -193,7 +212,13 @@ export default function BulkEditTransactionsDialog({
               control={control}
               name="typeEnabled"
               render={({ field: { value, onChange } }) => (
-                <Checkbox checked={value} onCheckedChange={onChange} />
+                <Checkbox
+                  checked={value}
+                  onCheckedChange={(checked) => {
+                    onChange(checked);
+                    if (!checked) setValue('type', 'Expense');
+                  }}
+                />
               )}
             />
             <Label className="w-24 shrink-0">Type</Label>
@@ -226,7 +251,13 @@ export default function BulkEditTransactionsDialog({
               control={control}
               name="categoryEnabled"
               render={({ field: { value, onChange } }) => (
-                <Checkbox checked={value} onCheckedChange={onChange} />
+                <Checkbox
+                  checked={value}
+                  onCheckedChange={(checked) => {
+                    onChange(checked);
+                    if (!checked) setValue('categoryId', '');
+                  }}
+                />
               )}
             />
             <Label className="w-24 shrink-0">Category</Label>
@@ -235,7 +266,11 @@ export default function BulkEditTransactionsDialog({
                 control={control}
                 name="categoryId"
                 render={({ field: { value, onChange } }) => (
-                  <CategoryAutocomplete value={value} onChange={onChange} />
+                  <CategoryAutocomplete
+                    value={value}
+                    onChange={onChange}
+                    disabled={!categoryEnabled}
+                  />
                 )}
               />
             </div>

--- a/components/CategoryAutocomplete.tsx
+++ b/components/CategoryAutocomplete.tsx
@@ -11,12 +11,14 @@ type Props = {
   value: string;
   onChange: (value: string) => void;
   fullWidth?: boolean;
+  disabled?: boolean;
 };
 
 export default function CategoryAutocomplete({
   value,
   onChange,
   fullWidth = true,
+  disabled = false,
 }: Props) {
   const trpc = useTRPC();
   const { data: categories } = useQuery(trpc.categories.list.queryOptions());
@@ -39,6 +41,7 @@ export default function CategoryAutocomplete({
       placeholder="Select category..."
       emptyMessage="No categories found."
       fullWidth={fullWidth}
+      disabled={disabled}
       renderOption={(option) => (
         <CategoryOptionContent option={option} categories={categories ?? []} />
       )}

--- a/components/combobox.tsx
+++ b/components/combobox.tsx
@@ -30,6 +30,7 @@ type Props = {
   placeholder?: string;
   emptyMessage?: string;
   fullWidth?: boolean;
+  disabled?: boolean;
   renderOption?: (option: Option) => ReactNode;
 };
 
@@ -40,6 +41,7 @@ export default function Combobox({
   placeholder = 'Select...',
   emptyMessage = 'No options found.',
   fullWidth = false,
+  disabled = false,
   renderOption,
 }: Props) {
   const [open, setOpen] = useState(false);
@@ -59,6 +61,7 @@ export default function Combobox({
           variant="outline"
           role="combobox"
           aria-expanded={open}
+          disabled={disabled}
           className={cn('justify-between', fullWidth ? 'w-full' : 'w-[200px]')}
         >
           <span className="flex flex-1 items-center truncate">


### PR DESCRIPTION
## Summary
- Disable field inputs when their corresponding checkbox is unticked (added `disabled` prop to `Combobox` and `CategoryAutocomplete` for the category field).
- Reset/clear field values when unticking a checkbox, so stale values are not accidentally submitted.

Closes #272

## Test plan
- [ ] Open the bulk edit dialog with multiple transactions selected
- [ ] Verify all field inputs are disabled when their checkboxes are unticked
- [ ] Tick a checkbox, enter a value, then untick it — verify the input is cleared
- [ ] Verify the category combobox is properly disabled when its checkbox is unticked
- [ ] Submit a bulk edit with some fields enabled and verify only enabled fields are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)