### PR TITLE
feat: improve CSV import preset dialog UX

### DIFF
--- a/components/CreateUpdateCSVImportPresetDialog/AIPresetDetector.tsx
+++ b/components/CreateUpdateCSVImportPresetDialog/AIPresetDetector.tsx
@@ -69,7 +69,7 @@ export default function AIPresetDetector({ onDetected, onSkip }: Props) {
   );
 
   return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-6">
+    <div className="flex min-h-full w-full flex-col items-center justify-center gap-6">
       <Card className="flex w-full max-w-md flex-col items-center gap-4 p-8">
         <Sparkles className="size-10 text-muted-foreground" />
         <div>

--- a/components/CreateUpdateCSVImportPresetDialog/PresetForm.tsx
+++ b/components/CreateUpdateCSVImportPresetDialog/PresetForm.tsx
@@ -59,80 +59,84 @@ export default function PresetForm({
   } = fieldArray;
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-col gap-3 overflow-x-hidden pb-1">
-      <div className="flex flex-col gap-1">
-        <Label htmlFor="name">Name</Label>
-        <Input id="name" {...register('name', { required: true })} />
-        {errors.name ? (
-          <p className="text-xs text-destructive">Name is required.</p>
-        ) : null}
-      </div>
+    <div className="grid min-h-0 min-w-0 gap-3 overflow-x-hidden pb-1 xl:grid-cols-[20rem_minmax(0,1fr)]">
+      <div className="min-h-0 space-y-3 overflow-y-auto pr-1">
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="name">Name</Label>
+          <Input id="name" {...register('name', { required: true })} />
+          {errors.name ? (
+            <p className="text-xs text-destructive">Name is required.</p>
+          ) : null}
+        </div>
 
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <div className="flex flex-col gap-1">
-          <Label htmlFor="decimal">Decimal character</Label>
-          <Input id="decimal" {...register('decimal', { required: true })} />
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label htmlFor="delimiter">CSV delimiter</Label>
-          <Input
-            id="delimiter"
-            {...register('delimiter', { required: true })}
-          />
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label htmlFor="rowsToSkipStart">Skip rows start</Label>
-          <Input
-            id="rowsToSkipStart"
-            type="number"
-            step={1}
-            {...register('rowsToSkipStart', { required: true })}
-          />
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label htmlFor="rowsToSkipEnd">Skip rows end</Label>
-          <Input
-            id="rowsToSkipEnd"
-            type="number"
-            step={1}
-            {...register('rowsToSkipEnd', { required: true })}
-          />
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <Label htmlFor="dateFormat">Date format</Label>
-        <Controller
-          control={control}
-          name="dateFormat"
-          render={({ field }) => (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-1">
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="decimal">Decimal character</Label>
+            <Input id="decimal" {...register('decimal', { required: true })} />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="delimiter">CSV delimiter</Label>
             <Input
-              {...field}
-              id="dateFormat"
-              list="date-format-options"
-              placeholder="yyyy-MM-dd"
+              id="delimiter"
+              {...register('delimiter', { required: true })}
             />
-          )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="rowsToSkipStart">Skip rows start</Label>
+            <Input
+              id="rowsToSkipStart"
+              type="number"
+              step={1}
+              {...register('rowsToSkipStart', { required: true })}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="rowsToSkipEnd">Skip rows end</Label>
+            <Input
+              id="rowsToSkipEnd"
+              type="number"
+              step={1}
+              {...register('rowsToSkipEnd', { required: true })}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="dateFormat">Date format</Label>
+          <Controller
+            control={control}
+            name="dateFormat"
+            render={({ field }) => (
+              <Input
+                {...field}
+                id="dateFormat"
+                list="date-format-options"
+                placeholder="yyyy-MM-dd"
+              />
+            )}
+          />
+          <datalist id="date-format-options">
+            {dateFormats.map((dateFormat) => (
+              <option key={dateFormat} value={dateFormat} />
+            ))}
+          </datalist>
+        </div>
+
+        <ImportFields
+          fields={fields.map((field) => field.value)}
+          onAppend={(value) => appendItem({ id: value, value })}
+          onRemove={removeItem}
+          onMove={moveItem}
         />
-        <datalist id="date-format-options">
-          {dateFormats.map((dateFormat) => (
-            <option key={dateFormat} value={dateFormat} />
-          ))}
-        </datalist>
       </div>
 
-      <ImportFields
-        fields={fields.map((field) => field.value)}
-        onAppend={(value) => appendItem({ id: value, value })}
-        onRemove={removeItem}
-        onMove={moveItem}
-      />
-
-      <ImportPreview
-        watch={watch}
-        fileData={fileData}
-        onFileDataChange={onFileDataChange}
-      />
+      <div className="min-w-0">
+        <ImportPreview
+          watch={watch}
+          fileData={fileData}
+          onFileDataChange={onFileDataChange}
+        />
+      </div>
     </div>
   );
 }

--- a/components/CreateUpdateCSVImportPresetDialog/index.tsx
+++ b/components/CreateUpdateCSVImportPresetDialog/index.tsx
@@ -139,7 +139,7 @@ export default function CreateUpdateCSVImportPresetDialog({
     >
       <DialogContent
         id={id}
-        className="flex h-[calc(100dvh-2rem)] flex-col overflow-hidden max-w-[calc(100dvw-2rem)] sm:max-w-[calc(100dvw-2rem)]"
+        className="flex h-[calc(100dvh-2rem)] max-h-[56rem] w-[calc(100dvw-2rem)] max-w-[calc(100dvw-2rem)] flex-col overflow-hidden sm:max-w-[calc(100dvw-2rem)] xl:max-w-7xl"
       >
         <DialogTitle className="sr-only">{title}</DialogTitle>
         <form
@@ -152,7 +152,13 @@ export default function CreateUpdateCSVImportPresetDialog({
             <h2 className="text-sm font-medium">{title}</h2>
           </DialogHeader>
 
-          <div className="min-h-0 flex-1 overflow-y-auto">
+          <div
+            className={
+              step === 'ai-detect'
+                ? 'min-h-0 flex flex-1 items-center justify-center overflow-y-auto'
+                : 'min-h-0 flex-1 overflow-y-auto'
+            }
+          >
             {step === 'ai-detect' ? (
               <AIPresetDetector
                 onDetected={handleDetected}

--- a/components/ImportFields.tsx
+++ b/components/ImportFields.tsx
@@ -1,16 +1,34 @@
 'use client';
 
-import { ArrowDown, ArrowUp, Trash2 } from 'lucide-react';
-import { type CSVImportField, CSVImportFields } from '@/lib/importPresets';
-import { Button } from './ui/button';
-import { Card } from './ui/card';
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from './ui/select';
+} from '@/components/ui/select';
+import { type CSVImportField, CSVImportFields } from '@/lib/importPresets';
+import { cn } from '@/lib/utils';
 
 type Props = {
   fields: CSVImportField[];
@@ -26,6 +44,39 @@ export default function ImportFields({
   onMove,
 }: Props) {
   const fieldRows = toFieldRows(fields);
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 4,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (!over || active.id === over.id) {
+      return;
+    }
+
+    const previousOrder = fieldRows.map((row) => row.key);
+    const oldIndex = previousOrder.indexOf(String(active.id));
+    const newIndex = previousOrder.indexOf(String(over.id));
+
+    if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) {
+      return;
+    }
+
+    const nextOrder = arrayMove(previousOrder, oldIndex, newIndex);
+    const nextIndex = nextOrder.indexOf(String(active.id));
+
+    if (nextIndex !== -1 && nextIndex !== oldIndex) {
+      onMove(oldIndex, nextIndex);
+    }
+  };
 
   return (
     <div className="flex flex-col gap-2">
@@ -49,55 +100,94 @@ export default function ImportFields({
 
       <Card className="gap-0 py-0">
         {fields.length > 0 ? (
-          <div className="divide-y">
-            {fieldRows.map(({ key, field, index }) => (
-              <div
-                key={key}
-                className="flex items-center justify-between px-4 py-2"
-              >
-                <p className="text-xs text-muted-foreground">{field}</p>
-                <div className="flex items-center gap-1">
-                  {index > 0 ? (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => onMove(index, index - 1)}
-                      aria-label={`Move ${field} up`}
-                    >
-                      <ArrowUp className="size-4" />
-                    </Button>
-                  ) : null}
-                  {index < fields.length - 1 ? (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => onMove(index, index + 1)}
-                      aria-label={`Move ${field} down`}
-                    >
-                      <ArrowDown className="size-4" />
-                    </Button>
-                  ) : null}
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={() => onRemove(index)}
-                    aria-label={`Remove ${field}`}
-                  >
-                    <Trash2 className="size-4" />
-                  </Button>
-                </div>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={fieldRows.map((row) => row.key)}
+              strategy={verticalListSortingStrategy}
+            >
+              <div className="divide-y">
+                {fieldRows.map(({ key, field, index }) => (
+                  <SortableFieldRow
+                    key={key}
+                    id={key}
+                    field={field}
+                    itemIndex={index}
+                    onRemove={onRemove}
+                  />
+                ))}
               </div>
-            ))}
-          </div>
+            </SortableContext>
+          </DndContext>
         ) : (
           <p className="px-4 py-3 text-xs text-muted-foreground">
             No fields selected
           </p>
         )}
       </Card>
+    </div>
+  );
+}
+
+type SortableFieldRowArgs = {
+  id: string;
+  field: CSVImportField;
+  itemIndex: number;
+  onRemove: (index: number) => void;
+};
+
+function SortableFieldRow({
+  id,
+  field,
+  itemIndex,
+  onRemove,
+}: SortableFieldRowArgs) {
+  const {
+    setNodeRef,
+    setActivatorNodeRef,
+    attributes,
+    listeners,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        'flex items-center gap-1 px-2 py-1',
+        isDragging ? 'bg-muted/60' : '',
+      )}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+    >
+      <Button
+        ref={setActivatorNodeRef}
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        aria-label={`Reorder ${field}`}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="size-3 text-muted-foreground" />
+      </Button>
+      <p className="min-w-0 flex-1 truncate text-xs text-foreground">{field}</p>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        onClick={() => onRemove(itemIndex)}
+        aria-label={`Remove ${field}`}
+      >
+        <Trash2 className="size-3.5" />
+      </Button>
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.30",
     "@base-ui/react": "^1.1.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@supercharge/promise-pool": "^3.2.0",
     "@tabler/icons-react": "^3.36.1",
     "@tanstack/react-query": "^5.90.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -403,6 +403,37 @@
   resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.14.tgz#44405162f255fe153a5ff99379510c058bf7a1e8"
   integrity sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ==
 
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz#3b4202bd6bb370a0730f6734867785919beac6af"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.3.1.tgz#4c36406a62c7baac499726f899935f93f0e6d003"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-10.0.0.tgz#1f9382b90d835cd5c65d92824fa9dafb78c4c3e8"
+  integrity sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@dotenvx/dotenvx@^1.48.4":
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/@dotenvx/dotenvx/-/dotenvx-1.52.0.tgz#39cb1a70eead336171d9de4cc9de4aa23b709547"


### PR DESCRIPTION
## Summary
- add drag-and-drop field reordering using dnd-kit in the import field mapping list
- redesign the preset form layout to use space better and avoid oversized blank areas
- widen the dialog on desktop, vertically center the AI-detect step, and compact sortable field rows

## Testing
- yarn biome check components/CreateUpdateCSVImportPresetDialog/AIPresetDetector.tsx components/CreateUpdateCSVImportPresetDialog/index.tsx components/CreateUpdateCSVImportPresetDialog/PresetForm.tsx components/ImportFields.tsx

Closes #277