### PR TITLE
feat: #281 - reduce layout padding for small screens

### DIFF
--- a/app/dashboard/accounts/page.tsx
+++ b/app/dashboard/accounts/page.tsx
@@ -82,7 +82,7 @@ export default function AccountsPage() {
     <div
       className="flex min-h-0 flex-col gap-4 overflow-hidden"
       style={{
-        height: 'calc(100dvh - var(--header-height) - 2rem)',
+        height: 'calc(100dvh - var(--header-height) - var(--content-padding) * 2)',
       }}
     >
       {hasAccounts && total ? (

--- a/app/dashboard/budget/page.tsx
+++ b/app/dashboard/budget/page.tsx
@@ -172,7 +172,7 @@ export default function BudgetPage() {
     <div
       className="flex min-h-0 flex-col gap-4 overflow-hidden"
       style={{
-        height: 'calc(100dvh - var(--header-height) - 2rem)',
+        height: 'calc(100dvh - var(--header-height) - var(--content-padding) * 2)',
       }}
     >
       <div className="flex shrink-0 flex-row items-center gap-2">

--- a/app/dashboard/categories/page.tsx
+++ b/app/dashboard/categories/page.tsx
@@ -82,7 +82,7 @@ export default function CategoriesPage() {
     <div
       className="flex min-h-0 flex-col gap-4 overflow-hidden"
       style={{
-        height: 'calc(100dvh - var(--header-height) - 2rem)',
+        height: 'calc(100dvh - var(--header-height) - var(--content-padding) * 2)',
       }}
     >
       <div className="flex shrink-0 flex-row items-center gap-3">

--- a/app/dashboard/exchange-rates/page.tsx
+++ b/app/dashboard/exchange-rates/page.tsx
@@ -58,7 +58,7 @@ export default function ExchangeRatesPage() {
     <div
       className="flex min-h-0 flex-col gap-4 overflow-hidden"
       style={{
-        height: 'calc(100dvh - var(--header-height) - 2rem)',
+        height: 'calc(100dvh - var(--header-height) - var(--content-padding) * 2)',
       }}
     >
       <div className="flex shrink-0 flex-row items-center justify-between gap-3">

--- a/app/dashboard/import-presets/page.tsx
+++ b/app/dashboard/import-presets/page.tsx
@@ -61,7 +61,7 @@ export default function ImportPresetsPage() {
     <div
       className="flex min-h-0 flex-col gap-4 overflow-hidden"
       style={{
-        height: 'calc(100dvh - var(--header-height) - 2rem)',
+        height: 'calc(100dvh - var(--header-height) - var(--content-padding) * 2)',
       }}
     >
       <div className="flex shrink-0 items-center justify-end">

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -16,7 +16,7 @@ export default function DashboardLayout({ children }: React.PropsWithChildren) {
       <AppSidebar />
       <SidebarInset>
         <SiteHeader />
-        <div className="flex flex-1 min-h-0 flex-col p-4 w-full">
+        <div className="flex flex-1 min-h-0 flex-col p-(--content-padding) [--content-padding:0.5rem] md:[--content-padding:1rem] w-full">
           <div className="@container/main flex flex-1 min-h-0 flex-col gap-2">
             <Suspense>{children}</Suspense>
           </div>

--- a/app/dashboard/transactions/page.tsx
+++ b/app/dashboard/transactions/page.tsx
@@ -224,7 +224,7 @@ export default function TransactionsPage() {
     <div
       className="flex min-h-0 flex-col gap-4 overflow-hidden pt-2"
       style={{
-        height: 'calc(100dvh - var(--header-height) - 2rem)',
+        height: 'calc(100dvh - var(--header-height) - var(--content-padding) * 2)',
       }}
     >
       <div className="flex shrink-0 flex-row items-center gap-3">

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -34,7 +34,7 @@ export function SiteHeader() {
 
   return (
     <header className="sticky top-0 z-50 bg-background flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
-      <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
+      <div className="flex w-full items-center gap-1 px-2 md:px-4 lg:gap-2 lg:px-6">
         <SidebarTrigger className="-ml-1" />
         <Separator
           orientation="vertical"


### PR DESCRIPTION
## Summary
- Introduces a `--content-padding` CSS variable on the dashboard layout wrapper (`0.5rem` on small screens, `1rem` on `md+`)
- Reduces header horizontal padding from `px-4` to `px-2` on small screens (`md:px-4` preserves existing desktop behavior)
- Updates all 6 page height calculations to reference `--content-padding` instead of the hardcoded `2rem`, keeping them in sync with the actual padding

Closes #281

## Test plan
- [ ] Verify padding is reduced on viewports below `md` breakpoint (768px)
- [ ] Verify padding remains unchanged on `md+` viewports
- [ ] Verify page content fills the viewport correctly (no overflow or gap) at all breakpoints
- [ ] Verify header padding matches content area padding on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)