### PR TITLE
feat: #283 - use colour pills for categories in budget table

### DIFF
--- a/components/BudgetTable.tsx
+++ b/components/BudgetTable.tsx
@@ -3,6 +3,7 @@
 import type { ColumnDef } from '@tanstack/react-table';
 import { ArrowDownLeft, ArrowUpRight } from 'lucide-react';
 import { useMemo } from 'react';
+import CategoryPill from '@/components/CategoryPill';
 import { type ColumnMeta, DataTable } from '@/components/DataTable';
 import useSortFromUrl from '@/hooks/useSortFromUrl';
 import { Input } from '@/components/ui/input';
@@ -21,6 +22,7 @@ export type BudgetEntry = {
   type: 'Income' | 'Expense';
   categoryId: number;
   categoryName: string;
+  categoryColor: string;
   target: number;
   actual: number;
 };
@@ -115,6 +117,13 @@ export default function BudgetTable({
       {
         accessorKey: 'categoryName',
         header: 'Category',
+        cell: ({ row }) => (
+          <CategoryPill
+            categoryId={row.original.categoryId}
+            name={row.original.categoryName}
+            color={row.original.categoryColor}
+          />
+        ),
       },
       {
         accessorKey: 'target',

--- a/server/trpc/procedures/budget.ts
+++ b/server/trpc/procedures/budget.ts
@@ -101,6 +101,7 @@ const BudgetEntryOutputSchema = z.object({
   type: BudgetEntryTypeSchema,
   categoryId: z.number(),
   categoryName: z.string(),
+  categoryColor: z.string(),
   target: z.number(),
   actual: z.number(),
 });
@@ -155,7 +156,7 @@ const get = authedProcedure
       txQuery.execute(),
       db
         .selectFrom('category')
-        .select(['id', 'name'])
+        .select(['id', 'name', 'color'])
         .where('userId', '=', ctx.user.id)
         .where('deletedAt', 'is', null)
         .execute(),
@@ -201,6 +202,7 @@ const get = authedProcedure
         type: entry.type as 'Income' | 'Expense',
         categoryId: entry.categoryId,
         categoryName: categoriesById[entry.categoryId]?.name ?? 'Unknown',
+        categoryColor: categoriesById[entry.categoryId]?.color ?? '#6B7280',
         target: Math.round(multiplier * entry.target),
         actual: getActual(entry.categoryId, entry.type),
       })),
@@ -208,6 +210,7 @@ const get = authedProcedure
         type: 'Expense' as const,
         categoryId: category.id,
         categoryName: category.name,
+        categoryColor: category.color,
         target: 0,
         actual: getActual(category.id, null),
       })),


### PR DESCRIPTION
## Summary
- Add `categoryColor` to the budget procedure output so category colors are available on the client
- Replace plain text category names in the budget table with `CategoryPill` components (coloured badges), consistent with how categories are displayed in the transactions table

Closes #283

## Test plan
- [ ] Open the budget page and verify categories are displayed as coloured pills instead of plain text
- [ ] Verify clicking a category pill navigates to the transactions page filtered by that category
- [ ] Verify colours match the assigned category colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)