### PR TITLE
fix: default transaction type to Expense when not set by AI categorization

### DIFF
--- a/server/trpc/procedures/transactions.ts
+++ b/server/trpc/procedures/transactions.ts
@@ -224,6 +224,12 @@ const createTransactions = authedProcedure
       }
     }
 
+    for (const t of enriched) {
+      if (!t.type) {
+        t.type = 'Expense';
+      }
+    }
+
     const transactions = await db
       .insertInto('account_transaction')
       .values(
@@ -488,6 +494,12 @@ const importTransactions = authedProcedure
         if (enriched[i].categoryId === null && ai.categoryId) {
           enriched[i].categoryId = ai.categoryId;
         }
+      }
+    }
+
+    for (const t of enriched) {
+      if (!t.type) {
+        t.type = 'Expense';
       }
     }
 


### PR DESCRIPTION
## Summary
- When importing or bulk-creating transactions without AI categorization enabled (or when AI doesn't return a type), the `type` field was left as `undefined`, causing a `NOT NULL constraint failed: account_transaction_type` error on insert.
- Added a fallback that defaults `type` to `'Expense'` after AI categorization runs, only for transactions where type was not determined.

## Test plan
- [ ] Import a CSV file with AI categorization **disabled** — verify transactions are created with type `Expense`
- [ ] Import a CSV file with AI categorization **enabled** — verify AI-assigned types are preserved
- [ ] Bulk-create transactions without AI categorization — verify no constraint error

🤖 Generated with [Claude Code](https://claude.com/claude-code)